### PR TITLE
feat: Add multimodal support - image attachment feature

### DIFF
--- a/components/ChatInterface.tsx
+++ b/components/ChatInterface.tsx
@@ -3,19 +3,30 @@
 import { useState, useCallback } from 'react';
 import MessageList from './MessageList';
 import MessageInput from './MessageInput';
-import type { Message, ChatRequest, ChatResponse, ChatError } from '@/types/chat';
+import type { Message, ChatRequest, ChatResponse, ChatError, ImageUploadData, TextContent } from '@/types/chat';
 
 export default function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSendMessage = useCallback(async (message: string) => {
-    // ユーザーメッセージを追加
-    const userMessage: Message = {
-      role: 'user',
-      content: message,
-    };
+  const handleSendMessage = useCallback(async (message: string, image?: ImageUploadData) => {
+    // ユーザーメッセージを追加（画像がある場合はマルチモーダル形式）
+    const userMessage: Message = image
+      ? {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: message,
+            } as TextContent,
+            image.imageContent,
+          ],
+        }
+      : {
+          role: 'user',
+          content: message,
+        };
 
     setMessages((prev) => [...prev, userMessage]);
     setIsLoading(true);
@@ -26,6 +37,7 @@ export default function ChatInterface() {
       const requestBody: ChatRequest = {
         message,
         conversationHistory: messages,
+        image: image?.imageContent,
       };
 
       const response = await fetch('/api/chat', {

--- a/components/ImageUpload.tsx
+++ b/components/ImageUpload.tsx
@@ -1,0 +1,138 @@
+import { useRef, useCallback, memo } from 'react';
+import type { ImageUploadData } from '@/types/chat';
+import { convertFileToImageContent, createPreviewURL } from '@/lib/image-utils';
+
+interface ImageUploadProps {
+  onImageSelect: (imageData: ImageUploadData | null) => void;
+  currentImage: ImageUploadData | null;
+  disabled?: boolean;
+}
+
+function ImageUpload({ onImageSelect, currentImage, disabled = false }: ImageUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback(
+    async (file: File | null) => {
+      if (!file) {
+        onImageSelect(null);
+        return;
+      }
+
+      try {
+        const imageContent = await convertFileToImageContent(file);
+        const preview = createPreviewURL(file);
+
+        onImageSelect({
+          file,
+          preview,
+          imageContent,
+        });
+      } catch (error) {
+        alert(error instanceof Error ? error.message : '画像の処理に失敗しました。');
+        onImageSelect(null);
+      }
+    },
+    [onImageSelect]
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      handleFileChange(file || null);
+    },
+    [handleFileChange]
+  );
+
+  const handleButtonClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleRemoveImage = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    onImageSelect(null);
+  }, [onImageSelect]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        onChange={handleInputChange}
+        disabled={disabled}
+        className="hidden"
+        aria-label="画像ファイルを選択"
+      />
+
+      {!currentImage ? (
+        <button
+          type="button"
+          onClick={handleButtonClick}
+          disabled={disabled}
+          aria-label="画像を添付"
+          className="p-2 rounded-lg border border-border bg-white
+                     transition-all duration-300
+                     hover:bg-surface hover:border-primary hover:shadow-sm
+                     focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 text-secondary"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+        </button>
+      ) : (
+        <div className="relative group">
+          <div className="flex items-center gap-2 p-2 rounded-lg border border-border bg-surface">
+            <img
+              src={currentImage.preview}
+              alt="添付画像のプレビュー"
+              className="h-12 w-12 object-cover rounded"
+            />
+            <span className="text-sm text-secondary max-w-[100px] truncate">
+              {currentImage.file.name}
+            </span>
+            <button
+              type="button"
+              onClick={handleRemoveImage}
+              disabled={disabled}
+              aria-label="画像を削除"
+              className="p-1 rounded hover:bg-white transition-colors
+                         focus:outline-none focus:ring-2 focus:ring-primary
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 text-secondary hover:text-red-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default memo(ImageUpload);

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import type { Message as MessageType } from '@/types/chat';
+import type { Message as MessageType, TextContent, ImageContent } from '@/types/chat';
 
 interface MessageProps {
   message: MessageType;
@@ -7,6 +7,47 @@ interface MessageProps {
 
 function Message({ message }: MessageProps) {
   const isUser = message.role === 'user';
+
+  // コンテンツが文字列の場合と配列の場合で処理を分ける
+  const renderContent = () => {
+    if (typeof message.content === 'string') {
+      return (
+        <div className="text-sm md:text-base whitespace-pre-wrap break-words leading-relaxed">
+          {message.content}
+        </div>
+      );
+    }
+
+    // マルチモーダルコンテンツの場合
+    return (
+      <div className="flex flex-col gap-2">
+        {message.content.map((item, index) => {
+          if (item.type === 'text') {
+            const textItem = item as TextContent;
+            return (
+              <div
+                key={index}
+                className="text-sm md:text-base whitespace-pre-wrap break-words leading-relaxed"
+              >
+                {textItem.text}
+              </div>
+            );
+          } else if (item.type === 'image') {
+            const imageItem = item as ImageContent;
+            return (
+              <img
+                key={index}
+                src={`data:${imageItem.source.media_type};base64,${imageItem.source.data}`}
+                alt="添付画像"
+                className="max-w-full rounded-lg shadow-sm"
+              />
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  };
 
   return (
     <div
@@ -23,9 +64,7 @@ function Message({ message }: MessageProps) {
             : 'bg-ai-message-bg text-ai-message-text mr-auto hover:bg-surface-hover'
         }`}
       >
-        <div className="text-sm md:text-base whitespace-pre-wrap break-words leading-relaxed">
-          {message.content}
-        </div>
+        {renderContent()}
       </div>
     </div>
   );

--- a/components/MessageInput.tsx
+++ b/components/MessageInput.tsx
@@ -1,20 +1,24 @@
 import { useState, KeyboardEvent, useCallback, memo } from 'react';
+import ImageUpload from './ImageUpload';
+import type { ImageUploadData } from '@/types/chat';
 
 interface MessageInputProps {
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string, image?: ImageUploadData) => void;
   isLoading: boolean;
 }
 
 function MessageInput({ onSendMessage, isLoading }: MessageInputProps) {
   const [input, setInput] = useState('');
   const [isComposing, setIsComposing] = useState(false);
+  const [imageData, setImageData] = useState<ImageUploadData | null>(null);
 
   const handleSend = useCallback(() => {
     if (input.trim() && !isLoading) {
-      onSendMessage(input.trim());
+      onSendMessage(input.trim(), imageData || undefined);
       setInput('');
+      setImageData(null);
     }
-  }, [input, isLoading, onSendMessage]);
+  }, [input, isLoading, imageData, onSendMessage]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
     // IME変換中はEnterキーでの送信を無効化
@@ -38,56 +42,63 @@ function MessageInput({ onSendMessage, isLoading }: MessageInputProps) {
     <div className="border-t border-border bg-surface p-4 shadow-md" role="complementary">
       <form
         onSubmit={(e) => { e.preventDefault(); handleSend(); }}
-        className="flex gap-3 max-w-4xl mx-auto"
+        className="flex flex-col gap-3 max-w-4xl mx-auto"
         aria-label="メッセージ入力フォーム"
       >
-        <label htmlFor="message-input" className="sr-only">
-          メッセージを入力
-        </label>
-        <textarea
-          id="message-input"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onCompositionStart={handleCompositionStart}
-          onCompositionEnd={handleCompositionEnd}
-          placeholder="メッセージを入力..."
-          disabled={isLoading}
-          rows={1}
-          aria-label="メッセージ入力欄"
-          aria-describedby="message-input-help"
-          className="flex-1 resize-none rounded-lg border border-border px-4 py-3
-                     bg-white
-                     transition-all duration-300
-                     hover:border-border-hover hover:shadow-sm
-                     focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent focus:shadow-md
-                     disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-surface"
-        />
-        <span id="message-input-help" className="sr-only">
-          Shift + Enterで改行、Enterで送信
-        </span>
-        <button
-          type="submit"
-          onClick={handleSend}
-          disabled={!input.trim() || isLoading}
-          aria-label={isLoading ? 'メッセージ送信中' : 'メッセージを送信'}
-          className="px-6 py-3 bg-primary text-white rounded-lg font-medium
-                     shadow-sm
-                     transition-all duration-300
-                     hover:bg-primary-700 hover:shadow-md hover:scale-105
-                     active:scale-95
-                     focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
-                     disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
-        >
-          {isLoading ? (
-            <span className="flex items-center gap-2">
-              <span className="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
-              送信中...
-            </span>
-          ) : (
-            '送信'
-          )}
-        </button>
+        <div className="flex gap-3">
+          <ImageUpload
+            onImageSelect={setImageData}
+            currentImage={imageData}
+            disabled={isLoading}
+          />
+          <label htmlFor="message-input" className="sr-only">
+            メッセージを入力
+          </label>
+          <textarea
+            id="message-input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            placeholder="メッセージを入力..."
+            disabled={isLoading}
+            rows={1}
+            aria-label="メッセージ入力欄"
+            aria-describedby="message-input-help"
+            className="flex-1 resize-none rounded-lg border border-border px-4 py-3
+                       bg-white
+                       transition-all duration-300
+                       hover:border-border-hover hover:shadow-sm
+                       focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent focus:shadow-md
+                       disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-surface"
+          />
+          <span id="message-input-help" className="sr-only">
+            Shift + Enterで改行、Enterで送信
+          </span>
+          <button
+            type="submit"
+            onClick={handleSend}
+            disabled={!input.trim() || isLoading}
+            aria-label={isLoading ? 'メッセージ送信中' : 'メッセージを送信'}
+            className="px-6 py-3 bg-primary text-white rounded-lg font-medium
+                       shadow-sm
+                       transition-all duration-300
+                       hover:bg-primary-700 hover:shadow-md hover:scale-105
+                       active:scale-95
+                       focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
+                       disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          >
+            {isLoading ? (
+              <span className="flex items-center gap-2">
+                <span className="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+                送信中...
+              </span>
+            ) : (
+              '送信'
+            )}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/components/__tests__/ImageUpload.test.tsx
+++ b/components/__tests__/ImageUpload.test.tsx
@@ -1,0 +1,592 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageUpload from '../ImageUpload';
+import type { ImageUploadData } from '@/types/chat';
+import * as imageUtils from '@/lib/image-utils';
+
+// Mock the image-utils module
+jest.mock('@/lib/image-utils');
+
+describe('ImageUpload', () => {
+  const mockOnImageSelect = jest.fn();
+  const mockConvertFileToImageContent = imageUtils.convertFileToImageContent as jest.MockedFunction<typeof imageUtils.convertFileToImageContent>;
+  const mockCreatePreviewURL = imageUtils.createPreviewURL as jest.MockedFunction<typeof imageUtils.createPreviewURL>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトのモック実装
+    mockCreatePreviewURL.mockReturnValue('blob:http://localhost/mock-preview');
+    mockConvertFileToImageContent.mockResolvedValue({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'mock-base64-data',
+      },
+    });
+  });
+
+  describe('Initial rendering', () => {
+    it('renders image upload button when no image is selected', () => {
+      // Given: No current image
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      // Then: Upload button should be visible
+      const uploadButton = screen.getByLabelText('画像を添付');
+      expect(uploadButton).toBeInTheDocument();
+      expect(uploadButton).toHaveAttribute('type', 'button');
+    });
+
+    it('renders hidden file input with correct accept attribute', () => {
+      // Given: No current image
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      // Then: Hidden file input should exist with correct attributes
+      const fileInput = screen.getByLabelText('画像ファイルを選択');
+      expect(fileInput).toBeInTheDocument();
+      expect(fileInput).toHaveAttribute('type', 'file');
+      expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/gif,image/webp');
+      expect(fileInput).toHaveClass('hidden');
+    });
+
+    it('renders image preview when image is selected', () => {
+      // Given: Current image data
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      // When: Component is rendered with current image
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      // Then: Preview should be displayed
+      const previewImage = screen.getByAltText('添付画像のプレビュー');
+      expect(previewImage).toBeInTheDocument();
+      expect(previewImage).toHaveAttribute('src', 'blob:http://localhost/test-preview');
+
+      // And: File name should be displayed
+      expect(screen.getByText('test.png')).toBeInTheDocument();
+
+      // And: Remove button should be visible
+      const removeButton = screen.getByLabelText('画像を削除');
+      expect(removeButton).toBeInTheDocument();
+    });
+  });
+
+  describe('File selection functionality', () => {
+    it('triggers file input when upload button is clicked', async () => {
+      // Given: Component with no image
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const uploadButton = screen.getByLabelText('画像を添付');
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+
+      // Create a spy on the click method
+      const clickSpy = jest.spyOn(fileInput, 'click');
+
+      // When: Upload button is clicked
+      await user.click(uploadButton);
+
+      // Then: File input click should be triggered
+      expect(clickSpy).toHaveBeenCalled();
+      clickSpy.mockRestore();
+    });
+
+    it('processes valid image file selection successfully', async () => {
+      // Given: Component with no image
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+      const testFile = new File(['test image content'], 'test-image.png', { type: 'image/png' });
+
+      // When: Valid image file is selected
+      await user.upload(fileInput, testFile);
+
+      // Then: Image processing functions should be called
+      await waitFor(() => {
+        expect(mockConvertFileToImageContent).toHaveBeenCalledWith(testFile);
+        expect(mockCreatePreviewURL).toHaveBeenCalledWith(testFile);
+      });
+
+      // And: onImageSelect callback should be called with correct data
+      await waitFor(() => {
+        expect(mockOnImageSelect).toHaveBeenCalledWith({
+          file: testFile,
+          preview: 'blob:http://localhost/mock-preview',
+          imageContent: {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'mock-base64-data',
+            },
+          },
+        });
+      });
+    });
+
+    it('handles null file selection (user cancels)', async () => {
+      // Given: Component with no image
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+
+      // When: User cancels file selection (simulated by triggering change with no files)
+      await user.click(fileInput);
+      // Simulate cancellation by manually triggering change event with null
+      Object.defineProperty(fileInput, 'files', {
+        value: null,
+        writable: false,
+      });
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+      // Then: onImageSelect should be called with null
+      await waitFor(() => {
+        expect(mockOnImageSelect).toHaveBeenCalledWith(null);
+      });
+    });
+  });
+
+  describe('Image validation and error handling', () => {
+    it('displays error alert when image processing fails with unsupported format', async () => {
+      // Given: convertFileToImageContent throws error
+      const errorMessage = 'サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。';
+      mockConvertFileToImageContent.mockRejectedValueOnce(new Error(errorMessage));
+
+      // Mock window.alert
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+      const invalidFile = new File(['test'], 'test.txt', { type: 'text/plain' });
+
+      // When: Invalid file is selected
+      await user.upload(fileInput, invalidFile);
+
+      // Then: Error alert should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(errorMessage);
+      });
+
+      // And: onImageSelect should be called with null (resetting state)
+      expect(mockOnImageSelect).toHaveBeenCalledWith(null);
+
+      alertSpy.mockRestore();
+    });
+
+    it('displays error alert when image processing fails with file size exceeded', async () => {
+      // Given: convertFileToImageContent throws error
+      const errorMessage = 'ファイルサイズが大きすぎます。最大5MBまでです。';
+      mockConvertFileToImageContent.mockRejectedValueOnce(new Error(errorMessage));
+
+      // Mock window.alert
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+      const largeFile = new File(['x'.repeat(6 * 1024 * 1024)], 'large.png', { type: 'image/png' });
+
+      // When: Large file is selected
+      await user.upload(fileInput, largeFile);
+
+      // Then: Error alert should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(errorMessage);
+      });
+
+      // And: onImageSelect should be called with null
+      expect(mockOnImageSelect).toHaveBeenCalledWith(null);
+
+      alertSpy.mockRestore();
+    });
+
+    it('displays generic error message for non-Error exceptions', async () => {
+      // Given: convertFileToImageContent throws non-Error object
+      mockConvertFileToImageContent.mockRejectedValueOnce('String error');
+
+      // Mock window.alert
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+      const testFile = new File(['test'], 'test.png', { type: 'image/png' });
+
+      // When: File is selected and non-Error is thrown
+      await user.upload(fileInput, testFile);
+
+      // Then: Generic error message should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith('画像の処理に失敗しました。');
+      });
+
+      alertSpy.mockRestore();
+    });
+  });
+
+  describe('Image removal functionality', () => {
+    it('removes image when remove button is clicked', async () => {
+      // Given: Component with current image
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      const removeButton = screen.getByLabelText('画像を削除');
+
+      // When: Remove button is clicked
+      await user.click(removeButton);
+
+      // Then: onImageSelect should be called with null
+      expect(mockOnImageSelect).toHaveBeenCalledWith(null);
+    });
+
+    it('clears file input value when removing image', async () => {
+      // Given: Component with current image
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      const user = userEvent.setup();
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
+      const removeButton = screen.getByLabelText('画像を削除');
+
+      // When: Remove button is clicked
+      await user.click(removeButton);
+
+      // Then: File input value should be cleared
+      expect(fileInput.value).toBe('');
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('disables upload button when disabled prop is true', () => {
+      // Given: Component with disabled=true
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+          disabled={true}
+        />
+      );
+
+      // Then: Upload button should be disabled
+      const uploadButton = screen.getByLabelText('画像を添付');
+      expect(uploadButton).toBeDisabled();
+    });
+
+    it('disables file input when disabled prop is true', () => {
+      // Given: Component with disabled=true
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+          disabled={true}
+        />
+      );
+
+      // Then: File input should be disabled
+      const fileInput = screen.getByLabelText('画像ファイルを選択');
+      expect(fileInput).toBeDisabled();
+    });
+
+    it('disables remove button when disabled prop is true', () => {
+      // Given: Component with current image and disabled=true
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+          disabled={true}
+        />
+      );
+
+      // Then: Remove button should be disabled
+      const removeButton = screen.getByLabelText('画像を削除');
+      expect(removeButton).toBeDisabled();
+    });
+
+    it('enables all controls when disabled prop is false or undefined', () => {
+      // Given: Component with disabled=false (or undefined)
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+          disabled={false}
+        />
+      );
+
+      // Then: Upload button should be enabled
+      const uploadButton = screen.getByLabelText('画像を添付');
+      expect(uploadButton).not.toBeDisabled();
+
+      // And: File input should be enabled
+      const fileInput = screen.getByLabelText('画像ファイルを選択');
+      expect(fileInput).not.toBeDisabled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('provides aria-label for upload button', () => {
+      // Given: Component with no image
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      // Then: Upload button should have aria-label
+      const uploadButton = screen.getByLabelText('画像を添付');
+      expect(uploadButton).toHaveAttribute('aria-label', '画像を添付');
+    });
+
+    it('provides aria-label for file input', () => {
+      // Given: Component with no image
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      // Then: File input should have aria-label
+      const fileInput = screen.getByLabelText('画像ファイルを選択');
+      expect(fileInput).toHaveAttribute('aria-label', '画像ファイルを選択');
+    });
+
+    it('provides aria-label for remove button', () => {
+      // Given: Component with current image
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      // Then: Remove button should have aria-label
+      const removeButton = screen.getByLabelText('画像を削除');
+      expect(removeButton).toHaveAttribute('aria-label', '画像を削除');
+    });
+
+    it('provides alt text for preview image', () => {
+      // Given: Component with current image
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      // When: Component is rendered
+      render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      // Then: Preview image should have alt text
+      const previewImage = screen.getByAltText('添付画像のプレビュー');
+      expect(previewImage).toBeInTheDocument();
+    });
+  });
+
+  describe('Memoization behavior', () => {
+    it('does not re-render when props are unchanged', () => {
+      // Given: Component with initial props
+      const { rerender } = render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const firstRender = screen.getByLabelText('画像を添付');
+
+      // When: Component is re-rendered with same props
+      rerender(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      const secondRender = screen.getByLabelText('画像を添付');
+
+      // Then: DOM element should be the same (memo optimization)
+      expect(firstRender).toBe(secondRender);
+    });
+
+    it('re-renders when currentImage changes', () => {
+      // Given: Component with no image
+      const { rerender } = render(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={null}
+        />
+      );
+
+      expect(screen.getByLabelText('画像を添付')).toBeInTheDocument();
+
+      // When: currentImage prop is updated
+      const mockImageData: ImageUploadData = {
+        file: new File(['test'], 'test.png', { type: 'image/png' }),
+        preview: 'blob:http://localhost/test-preview',
+        imageContent: {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'test-data',
+          },
+        },
+      };
+
+      rerender(
+        <ImageUpload
+          onImageSelect={mockOnImageSelect}
+          currentImage={mockImageData}
+        />
+      );
+
+      // Then: Should now show preview instead of upload button
+      expect(screen.queryByLabelText('画像を添付')).not.toBeInTheDocument();
+      expect(screen.getByAltText('添付画像のプレビュー')).toBeInTheDocument();
+    });
+  });
+});

--- a/components/__tests__/ImageUpload.test.tsx
+++ b/components/__tests__/ImageUpload.test.tsx
@@ -12,6 +12,11 @@ describe('ImageUpload', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    // Restore all spies after each test to prevent redefinition errors
+    jest.restoreAllMocks();
+  });
+
   describe('Initial rendering', () => {
     it('renders image upload button when no image is selected', () => {
       // Given: No current image
@@ -108,7 +113,6 @@ describe('ImageUpload', () => {
       await waitFor(() => {
         expect(clickSpy).toHaveBeenCalled();
       });
-      clickSpy.mockRestore();
     });
 
     it('processes valid image file selection successfully', async () => {
@@ -143,9 +147,6 @@ describe('ImageUpload', () => {
         expect(callArg.file).toBe(testFile);
         expect(callArg.imageContent.type).toBe('image');
       }, { timeout: 3000 });
-
-      convertSpy.mockRestore();
-      previewSpy.mockRestore();
     });
 
     it('handles null file selection (user cancels)', async () => {
@@ -203,8 +204,6 @@ describe('ImageUpload', () => {
 
       // And: onImageSelect should be called with null (resetting state)
       expect(mockOnImageSelect).toHaveBeenCalledWith(null);
-
-      alertSpy.mockRestore();
     });
 
     it('displays error alert when image processing fails with file size exceeded', async () => {
@@ -236,8 +235,6 @@ describe('ImageUpload', () => {
 
       // And: onImageSelect should be called with null
       expect(mockOnImageSelect).toHaveBeenCalledWith(null);
-
-      alertSpy.mockRestore();
     });
 
     it('displays generic error message for non-Error exceptions', async () => {
@@ -268,9 +265,6 @@ describe('ImageUpload', () => {
 
       // And: onImageSelect should be called with null
       expect(mockOnImageSelect).toHaveBeenCalledWith(null);
-
-      alertSpy.mockRestore();
-      convertSpy.mockRestore();
     });
   });
 

--- a/components/__tests__/ImageUpload.test.tsx
+++ b/components/__tests__/ImageUpload.test.tsx
@@ -120,7 +120,9 @@ describe('ImageUpload', () => {
       await user.click(uploadButton);
 
       // Then: File input click should be triggered
-      expect(clickSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(clickSpy).toHaveBeenCalled();
+      });
       clickSpy.mockRestore();
     });
 
@@ -144,7 +146,7 @@ describe('ImageUpload', () => {
       await waitFor(() => {
         expect(mockConvertFileToImageContent).toHaveBeenCalledWith(testFile);
         expect(mockCreatePreviewURL).toHaveBeenCalledWith(testFile);
-      });
+      }, { timeout: 3000 });
 
       // And: onImageSelect callback should be called with correct data
       await waitFor(() => {
@@ -160,12 +162,11 @@ describe('ImageUpload', () => {
             },
           },
         });
-      });
+      }, { timeout: 3000 });
     });
 
     it('handles null file selection (user cancels)', async () => {
       // Given: Component with no image
-      const user = userEvent.setup();
       render(
         <ImageUpload
           onImageSelect={mockOnImageSelect}
@@ -176,7 +177,6 @@ describe('ImageUpload', () => {
       const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
 
       // When: User cancels file selection (simulated by triggering change with no files)
-      await user.click(fileInput);
       // Simulate cancellation by manually triggering change event with null
       Object.defineProperty(fileInput, 'files', {
         value: null,
@@ -187,7 +187,7 @@ describe('ImageUpload', () => {
       // Then: onImageSelect should be called with null
       await waitFor(() => {
         expect(mockOnImageSelect).toHaveBeenCalledWith(null);
-      });
+      }, { timeout: 3000 });
     });
   });
 

--- a/components/__tests__/ImageUpload.test.tsx
+++ b/components/__tests__/ImageUpload.test.tsx
@@ -193,12 +193,12 @@ describe('ImageUpload', () => {
 
   describe('Image validation and error handling', () => {
     it('displays error alert when image processing fails with unsupported format', async () => {
-      // Given: convertFileToImageContent throws error
+      // Given: Mock window.alert first
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      // Then set up the error mock
       const errorMessage = 'サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。';
       mockConvertFileToImageContent.mockRejectedValueOnce(new Error(errorMessage));
-
-      // Mock window.alert
-      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
 
       const user = userEvent.setup();
       render(
@@ -214,8 +214,14 @@ describe('ImageUpload', () => {
       // When: Invalid file is selected
       await user.upload(fileInput, invalidFile);
 
-      // Then: Error alert should be displayed
+      // Then: convertFileToImageContent should be called
       await waitFor(() => {
+        expect(mockConvertFileToImageContent).toHaveBeenCalledWith(invalidFile);
+      }, { timeout: 3000 });
+
+      // And: Error alert should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledTimes(1);
         expect(alertSpy).toHaveBeenCalledWith(errorMessage);
       }, { timeout: 3000 });
 
@@ -226,12 +232,12 @@ describe('ImageUpload', () => {
     });
 
     it('displays error alert when image processing fails with file size exceeded', async () => {
-      // Given: convertFileToImageContent throws error
+      // Given: Mock window.alert first
+      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      // Then set up the error mock
       const errorMessage = 'ファイルサイズが大きすぎます。最大5MBまでです。';
       mockConvertFileToImageContent.mockRejectedValueOnce(new Error(errorMessage));
-
-      // Mock window.alert
-      const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
 
       const user = userEvent.setup();
       render(
@@ -247,10 +253,16 @@ describe('ImageUpload', () => {
       // When: Large file is selected
       await user.upload(fileInput, largeFile);
 
-      // Then: Error alert should be displayed
+      // Then: convertFileToImageContent should be called
       await waitFor(() => {
+        expect(mockConvertFileToImageContent).toHaveBeenCalledWith(largeFile);
+      }, { timeout: 3000 });
+
+      // And: Error alert should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledTimes(1);
         expect(alertSpy).toHaveBeenCalledWith(errorMessage);
-      });
+      }, { timeout: 3000 });
 
       // And: onImageSelect should be called with null
       expect(mockOnImageSelect).toHaveBeenCalledWith(null);
@@ -259,11 +271,11 @@ describe('ImageUpload', () => {
     });
 
     it('displays generic error message for non-Error exceptions', async () => {
-      // Given: convertFileToImageContent throws non-Error object
-      mockConvertFileToImageContent.mockRejectedValueOnce('String error');
-
-      // Mock window.alert
+      // Given: Mock window.alert first
       const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+      // Then set up non-Error rejection
+      mockConvertFileToImageContent.mockRejectedValueOnce('String error');
 
       const user = userEvent.setup();
       render(
@@ -280,8 +292,14 @@ describe('ImageUpload', () => {
       // When: File is selected and non-Error is thrown
       await user.upload(fileInput, testFile);
 
-      // Then: Generic error message should be displayed
+      // Then: convertFileToImageContent should be called
       await waitFor(() => {
+        expect(mockConvertFileToImageContent).toHaveBeenCalledWith(testFile);
+      }, { timeout: 3000 });
+
+      // And: Generic error message should be displayed
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledTimes(1);
         expect(alertSpy).toHaveBeenCalledWith('画像の処理に失敗しました。');
       }, { timeout: 3000 });
 

--- a/components/__tests__/ImageUpload.test.tsx
+++ b/components/__tests__/ImageUpload.test.tsx
@@ -217,7 +217,7 @@ describe('ImageUpload', () => {
       // Then: Error alert should be displayed
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith(errorMessage);
-      });
+      }, { timeout: 3000 });
 
       // And: onImageSelect should be called with null (resetting state)
       expect(mockOnImageSelect).toHaveBeenCalledWith(null);
@@ -274,7 +274,8 @@ describe('ImageUpload', () => {
       );
 
       const fileInput = screen.getByLabelText('画像ファイルを選択') as HTMLInputElement;
-      const testFile = new File(['test'], 'test.png', { type: 'image/png' });
+      // Use a small file to avoid triggering size validation
+      const testFile = new File(['small test content'], 'test.png', { type: 'image/png' });
 
       // When: File is selected and non-Error is thrown
       await user.upload(fileInput, testFile);
@@ -282,7 +283,7 @@ describe('ImageUpload', () => {
       // Then: Generic error message should be displayed
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith('画像の処理に失敗しました。');
-      });
+      }, { timeout: 3000 });
 
       alertSpy.mockRestore();
     });

--- a/components/__tests__/MessageInput.test.tsx
+++ b/components/__tests__/MessageInput.test.tsx
@@ -38,7 +38,7 @@ describe('MessageInput', () => {
       await user.click(sendButton);
 
       // Then: onSendMessage should be called with trimmed text
-      expect(mockOnSendMessage).toHaveBeenCalledWith('Test message');
+      expect(mockOnSendMessage).toHaveBeenCalledWith('Test message', undefined);
     });
 
     it('clears input after sending message', async () => {
@@ -163,7 +163,7 @@ describe('MessageInput', () => {
       await user.click(sendButton);
 
       // Then: onSendMessage should be called with the message
-      expect(mockOnSendMessage).toHaveBeenCalledWith('Form submit test');
+      expect(mockOnSendMessage).toHaveBeenCalledWith('Form submit test', undefined);
       // Note: Called twice due to button onClick and form onSubmit, which is expected behavior
     });
 
@@ -210,7 +210,7 @@ describe('MessageInput', () => {
       await user.keyboard('{Enter}');
 
       // Then: Message should be sent
-      expect(mockOnSendMessage).toHaveBeenCalledWith('Enter key test');
+      expect(mockOnSendMessage).toHaveBeenCalledWith('Enter key test', undefined);
     });
 
     it('does not send message when Shift+Enter is pressed', async () => {
@@ -288,7 +288,7 @@ describe('MessageInput', () => {
       await user.keyboard('{Enter}');
 
       // Then: Message should be sent
-      expect(mockOnSendMessage).toHaveBeenCalledWith('こんにちは');
+      expect(mockOnSendMessage).toHaveBeenCalledWith('こんにちは', undefined);
     });
   });
 

--- a/lib/__tests__/image-utils.test.ts
+++ b/lib/__tests__/image-utils.test.ts
@@ -8,6 +8,10 @@ import {
   MAX_FILE_SIZE,
 } from '../image-utils';
 
+// Mock browser APIs for URL object
+global.URL.createObjectURL = jest.fn(() => 'blob:http://localhost/mock-url');
+global.URL.revokeObjectURL = jest.fn();
+
 describe('image-utils', () => {
   describe('Constants', () => {
     it('exports correct supported image types', () => {

--- a/lib/__tests__/image-utils.test.ts
+++ b/lib/__tests__/image-utils.test.ts
@@ -1,0 +1,508 @@
+import {
+  validateImageFile,
+  encodeImageToBase64,
+  convertFileToImageContent,
+  createPreviewURL,
+  revokePreviewURL,
+  SUPPORTED_IMAGE_TYPES,
+  MAX_FILE_SIZE,
+} from '../image-utils';
+
+describe('image-utils', () => {
+  describe('Constants', () => {
+    it('exports correct supported image types', () => {
+      // Given: SUPPORTED_IMAGE_TYPES constant
+      // Then: Should include all supported formats
+      expect(SUPPORTED_IMAGE_TYPES).toEqual([
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ]);
+    });
+
+    it('exports correct maximum file size (5MB)', () => {
+      // Given: MAX_FILE_SIZE constant
+      // Then: Should be 5MB in bytes
+      expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+      expect(MAX_FILE_SIZE).toBe(5242880);
+    });
+  });
+
+  describe('validateImageFile', () => {
+    describe('Valid files', () => {
+      it('validates PNG file successfully', () => {
+        // Given: Valid PNG file
+        const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      it('validates JPEG file successfully', () => {
+        // Given: Valid JPEG file
+        const file = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      it('validates GIF file successfully', () => {
+        // Given: Valid GIF file
+        const file = new File(['test'], 'test.gif', { type: 'image/gif' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      it('validates WebP file successfully', () => {
+        // Given: Valid WebP file
+        const file = new File(['test'], 'test.webp', { type: 'image/webp' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      it('validates file at maximum size limit', () => {
+        // Given: File exactly at 5MB limit
+        const fileContent = new Array(MAX_FILE_SIZE).fill('x').join('');
+        const file = new File([fileContent], 'large.png', { type: 'image/png' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      it('validates small file (1 byte)', () => {
+        // Given: Very small file
+        const file = new File(['x'], 'tiny.png', { type: 'image/png' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be valid
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('Invalid file types', () => {
+      it('rejects unsupported BMP format', () => {
+        // Given: BMP file (not supported)
+        const file = new File(['test'], 'test.bmp', { type: 'image/bmp' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid with appropriate error
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+
+      it('rejects SVG format', () => {
+        // Given: SVG file (not supported)
+        const file = new File(['test'], 'test.svg', { type: 'image/svg+xml' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+
+      it('rejects text file', () => {
+        // Given: Text file
+        const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+
+      it('rejects PDF file', () => {
+        // Given: PDF file
+        const file = new File(['test'], 'test.pdf', { type: 'application/pdf' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+
+      it('rejects file with empty MIME type', () => {
+        // Given: File with empty type
+        const file = new File(['test'], 'test', { type: '' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+    });
+
+    describe('File size validation', () => {
+      it('rejects file exceeding maximum size by 1 byte', () => {
+        // Given: File just over 5MB limit
+        const fileContent = new Array(MAX_FILE_SIZE + 1).fill('x').join('');
+        const file = new File([fileContent], 'toolarge.png', { type: 'image/png' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid with size error
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('ファイルサイズが大きすぎます。最大5MBまでです。');
+      });
+
+      it('rejects file significantly exceeding maximum size (10MB)', () => {
+        // Given: File at 10MB
+        const fileContent = new Array(10 * 1024 * 1024).fill('x').join('');
+        const file = new File([fileContent], 'verylarge.png', { type: 'image/png' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid with size error
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('ファイルサイズが大きすぎます。最大5MBまでです。');
+      });
+    });
+
+    describe('Combined validation', () => {
+      it('rejects file with both invalid type and size', () => {
+        // Given: Large text file (both invalid type and size)
+        const fileContent = new Array(MAX_FILE_SIZE + 1).fill('x').join('');
+        const file = new File([fileContent], 'large.txt', { type: 'text/plain' });
+
+        // When: File is validated
+        const result = validateImageFile(file);
+
+        // Then: Should be invalid (type check happens first)
+        expect(result.valid).toBe(false);
+        expect(result.error).toBe('サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。');
+      });
+    });
+  });
+
+  describe('encodeImageToBase64', () => {
+    it('encodes image file to base64 successfully', async () => {
+      // Given: PNG file
+      const fileContent = 'test image content';
+      const file = new File([fileContent], 'test.png', { type: 'image/png' });
+
+      // When: File is encoded
+      const result = await encodeImageToBase64(file);
+
+      // Then: Should return base64 string (without data URL prefix)
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+      // Base64 should not include the data URL prefix
+      expect(result).not.toMatch(/^data:/);
+    });
+
+    it('encodes different file types correctly', async () => {
+      // Given: JPEG file
+      const file = new File(['jpeg content'], 'test.jpg', { type: 'image/jpeg' });
+
+      // When: File is encoded
+      const result = await encodeImageToBase64(file);
+
+      // Then: Should return base64 string
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe('string');
+    });
+
+    it('encodes empty file', async () => {
+      // Given: Empty file
+      const file = new File([], 'empty.png', { type: 'image/png' });
+
+      // When: File is encoded
+      const result = await encodeImageToBase64(file);
+
+      // Then: Should return base64 string (may be empty or minimal)
+      expect(typeof result).toBe('string');
+    });
+
+    it('handles file read errors', async () => {
+      // Given: Mock FileReader with error
+      const originalFileReader = global.FileReader;
+      const mockFileReader = {
+        readAsDataURL: jest.fn(function(this: any) {
+          setTimeout(() => {
+            if (this.onerror) {
+              this.onerror(new Error('Read error'));
+            }
+          }, 0);
+        }),
+      } as any;
+
+      global.FileReader = jest.fn(() => mockFileReader) as any;
+
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+      // When: File encoding is attempted
+      // Then: Should reject with error
+      await expect(encodeImageToBase64(file)).rejects.toThrow('ファイルの読み込みに失敗しました。');
+
+      // Cleanup
+      global.FileReader = originalFileReader;
+    });
+
+    it('returns only base64 data without data URL prefix', async () => {
+      // Given: PNG file
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+      // When: File is encoded
+      const result = await encodeImageToBase64(file);
+
+      // Then: Result should be pure base64 (no "data:image/png;base64," prefix)
+      expect(result).not.toContain('data:');
+      expect(result).not.toContain(';base64,');
+      // Base64 typically contains alphanumeric and +/= characters
+      expect(result).toMatch(/^[A-Za-z0-9+/=]*$/);
+    });
+  });
+
+  describe('convertFileToImageContent', () => {
+    it('converts valid PNG file to ImageContent format', async () => {
+      // Given: Valid PNG file
+      const file = new File(['test image'], 'test.png', { type: 'image/png' });
+
+      // When: File is converted
+      const result = await convertFileToImageContent(file);
+
+      // Then: Should return proper ImageContent structure
+      expect(result).toHaveProperty('type', 'image');
+      expect(result).toHaveProperty('source');
+      expect(result.source).toHaveProperty('type', 'base64');
+      expect(result.source).toHaveProperty('media_type', 'image/png');
+      expect(result.source).toHaveProperty('data');
+      expect(typeof result.source.data).toBe('string');
+    });
+
+    it('converts valid JPEG file with correct media type', async () => {
+      // Given: Valid JPEG file
+      const file = new File(['jpeg data'], 'photo.jpg', { type: 'image/jpeg' });
+
+      // When: File is converted
+      const result = await convertFileToImageContent(file);
+
+      // Then: Should have correct JPEG media type
+      expect(result.source.media_type).toBe('image/jpeg');
+      expect(result.type).toBe('image');
+    });
+
+    it('converts valid GIF file with correct media type', async () => {
+      // Given: Valid GIF file
+      const file = new File(['gif data'], 'animation.gif', { type: 'image/gif' });
+
+      // When: File is converted
+      const result = await convertFileToImageContent(file);
+
+      // Then: Should have correct GIF media type
+      expect(result.source.media_type).toBe('image/gif');
+    });
+
+    it('converts valid WebP file with correct media type', async () => {
+      // Given: Valid WebP file
+      const file = new File(['webp data'], 'modern.webp', { type: 'image/webp' });
+
+      // When: File is converted
+      const result = await convertFileToImageContent(file);
+
+      // Then: Should have correct WebP media type
+      expect(result.source.media_type).toBe('image/webp');
+    });
+
+    it('throws error for invalid file type', async () => {
+      // Given: Invalid file type (SVG)
+      const file = new File(['svg'], 'image.svg', { type: 'image/svg+xml' });
+
+      // When: Attempting to convert
+      // Then: Should throw validation error
+      await expect(convertFileToImageContent(file)).rejects.toThrow(
+        'サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。'
+      );
+    });
+
+    it('throws error for file exceeding size limit', async () => {
+      // Given: File exceeding 5MB
+      const largeContent = new Array(MAX_FILE_SIZE + 1).fill('x').join('');
+      const file = new File([largeContent], 'huge.png', { type: 'image/png' });
+
+      // When: Attempting to convert
+      // Then: Should throw size error
+      await expect(convertFileToImageContent(file)).rejects.toThrow(
+        'ファイルサイズが大きすぎます。最大5MBまでです。'
+      );
+    });
+
+    it('throws error for text file', async () => {
+      // Given: Text file
+      const file = new File(['text content'], 'document.txt', { type: 'text/plain' });
+
+      // When: Attempting to convert
+      // Then: Should throw validation error
+      await expect(convertFileToImageContent(file)).rejects.toThrow(
+        'サポートされていないファイル形式です'
+      );
+    });
+
+    it('includes base64 data in result', async () => {
+      // Given: Valid image file
+      const file = new File(['image data'], 'test.png', { type: 'image/png' });
+
+      // When: File is converted
+      const result = await convertFileToImageContent(file);
+
+      // Then: Base64 data should be present and non-empty
+      expect(result.source.data).toBeTruthy();
+      expect(result.source.data.length).toBeGreaterThan(0);
+      // Should be valid base64
+      expect(result.source.data).toMatch(/^[A-Za-z0-9+/=]*$/);
+    });
+  });
+
+  describe('createPreviewURL', () => {
+    it('creates blob URL for image file', () => {
+      // Given: Image file
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+      // When: Preview URL is created
+      const url = createPreviewURL(file);
+
+      // Then: Should return blob URL
+      expect(url).toBeTruthy();
+      expect(url).toMatch(/^blob:/);
+    });
+
+    it('creates different URLs for different files', () => {
+      // Given: Two different files
+      const file1 = new File(['test1'], 'test1.png', { type: 'image/png' });
+      const file2 = new File(['test2'], 'test2.png', { type: 'image/png' });
+
+      // When: Preview URLs are created
+      const url1 = createPreviewURL(file1);
+      const url2 = createPreviewURL(file2);
+
+      // Then: URLs should be different
+      expect(url1).not.toBe(url2);
+    });
+
+    it('creates URL for any file type', () => {
+      // Given: Non-image file (URL.createObjectURL works for any blob)
+      const file = new File(['text'], 'test.txt', { type: 'text/plain' });
+
+      // When: Preview URL is created
+      const url = createPreviewURL(file);
+
+      // Then: Should still create a blob URL
+      expect(url).toMatch(/^blob:/);
+    });
+  });
+
+  describe('revokePreviewURL', () => {
+    it('revokes blob URL without throwing error', () => {
+      // Given: Blob URL
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+      const url = createPreviewURL(file);
+
+      // When: URL is revoked
+      // Then: Should not throw error
+      expect(() => revokePreviewURL(url)).not.toThrow();
+    });
+
+    it('handles revoking invalid URL gracefully', () => {
+      // Given: Invalid URL
+      const invalidUrl = 'not-a-blob-url';
+
+      // When: Attempting to revoke
+      // Then: Should not throw error (URL.revokeObjectURL handles this)
+      expect(() => revokePreviewURL(invalidUrl)).not.toThrow();
+    });
+
+    it('handles revoking already-revoked URL', () => {
+      // Given: Blob URL that has been revoked
+      const file = new File(['test'], 'test.png', { type: 'image/png' });
+      const url = createPreviewURL(file);
+      revokePreviewURL(url);
+
+      // When: Attempting to revoke again
+      // Then: Should not throw error
+      expect(() => revokePreviewURL(url)).not.toThrow();
+    });
+
+    it('handles empty string URL', () => {
+      // Given: Empty string
+      const url = '';
+
+      // When: Attempting to revoke
+      // Then: Should not throw error
+      expect(() => revokePreviewURL(url)).not.toThrow();
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('full workflow: validate, encode, and create preview for valid file', async () => {
+      // Given: Valid image file
+      const file = new File(['test image content'], 'photo.jpg', { type: 'image/jpeg' });
+
+      // When: Full workflow is executed
+      const validation = validateImageFile(file);
+      expect(validation.valid).toBe(true);
+
+      const imageContent = await convertFileToImageContent(file);
+      const previewUrl = createPreviewURL(file);
+
+      // Then: All operations should succeed
+      expect(imageContent.type).toBe('image');
+      expect(imageContent.source.media_type).toBe('image/jpeg');
+      expect(previewUrl).toMatch(/^blob:/);
+
+      // Cleanup
+      revokePreviewURL(previewUrl);
+    });
+
+    it('full workflow: reject invalid file before encoding', async () => {
+      // Given: Invalid file (too large)
+      const largeContent = new Array(MAX_FILE_SIZE + 1).fill('x').join('');
+      const file = new File([largeContent], 'huge.png', { type: 'image/png' });
+
+      // When: Validation is performed
+      const validation = validateImageFile(file);
+
+      // Then: Should fail validation
+      expect(validation.valid).toBe(false);
+      expect(validation.error).toBeTruthy();
+
+      // And: Conversion should throw
+      await expect(convertFileToImageContent(file)).rejects.toThrow();
+    });
+  });
+});

--- a/lib/__tests__/image-utils.test.ts
+++ b/lib/__tests__/image-utils.test.ts
@@ -9,7 +9,8 @@ import {
 } from '../image-utils';
 
 // Mock browser APIs for URL object
-global.URL.createObjectURL = jest.fn(() => 'blob:http://localhost/mock-url');
+let mockUrlCounter = 0;
+global.URL.createObjectURL = jest.fn(() => `blob:http://localhost/mock-url-${mockUrlCounter++}`);
 global.URL.revokeObjectURL = jest.fn();
 
 describe('image-utils', () => {

--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -1,0 +1,93 @@
+import type { ImageContent } from '@/types/chat';
+
+// サポートされている画像形式
+export const SUPPORTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const;
+
+// 最大ファイルサイズ (5MB)
+export const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+/**
+ * 画像ファイルのバリデーション
+ */
+export function validateImageFile(file: File): { valid: boolean; error?: string } {
+  // ファイルタイプのチェック
+  if (!SUPPORTED_IMAGE_TYPES.includes(file.type as any)) {
+    return {
+      valid: false,
+      error: 'サポートされていないファイル形式です。PNG、JPEG、GIF、WebPのみ対応しています。',
+    };
+  }
+
+  // ファイルサイズのチェック
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      valid: false,
+      error: `ファイルサイズが大きすぎます。最大${MAX_FILE_SIZE / 1024 / 1024}MBまでです。`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * ファイルをbase64エンコード
+ */
+export function encodeImageToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const base64String = reader.result as string;
+      // data:image/png;base64,... の形式から base64部分のみを抽出
+      const base64Data = base64String.split(',')[1];
+      resolve(base64Data);
+    };
+
+    reader.onerror = () => {
+      reject(new Error('ファイルの読み込みに失敗しました。'));
+    };
+
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * 画像ファイルをImageContent形式に変換
+ */
+export async function convertFileToImageContent(file: File): Promise<ImageContent> {
+  const validation = validateImageFile(file);
+
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  const base64Data = await encodeImageToBase64(file);
+
+  return {
+    type: 'image',
+    source: {
+      type: 'base64',
+      media_type: file.type as ImageContent['source']['media_type'],
+      data: base64Data,
+    },
+  };
+}
+
+/**
+ * プレビュー用のURL生成
+ */
+export function createPreviewURL(file: File): string {
+  return URL.createObjectURL(file);
+}
+
+/**
+ * プレビューURLのクリーンアップ
+ */
+export function revokePreviewURL(url: string): void {
+  URL.revokeObjectURL(url);
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,13 +1,33 @@
 // チャット関連の型定義
 
+// 画像コンテンツの型
+export interface ImageContent {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+    data: string;
+  };
+}
+
+// テキストコンテンツの型
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+// メッセージコンテンツの型（テキストのみ、または複数のコンテンツ）
+export type MessageContent = string | Array<TextContent | ImageContent>;
+
 export interface Message {
   role: 'user' | 'assistant';
-  content: string;
+  content: MessageContent;
 }
 
 export interface ChatRequest {
   message: string;
   conversationHistory: Message[];
+  image?: ImageContent; // オプショナルな画像
 }
 
 export interface ChatResponse {
@@ -18,4 +38,11 @@ export interface ChatResponse {
 export interface ChatError {
   error: string;
   statusCode: number;
+}
+
+// 画像アップロードの型
+export interface ImageUploadData {
+  file: File;
+  preview: string;
+  imageContent: ImageContent;
 }


### PR DESCRIPTION
## Summary

Implements image attachment functionality for the chat interface, allowing users to send images along with text messages to Claude AI.

### Changes

- Added multimodal type definitions (ImageContent, TextContent)
- Created ImageUpload component for file selection and preview
- Updated MessageInput to handle image attachments
- Updated Message component to display images in chat
- Modified API route to send multimodal content to Claude
- Added image validation and encoding utilities (5MB limit, PNG/JPEG/GIF/WebP)

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)